### PR TITLE
Add CI workflow configuration in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run a one-line script
+        run: echo Hello, world!
+
+      - name: Run a multi-line script
+        run: |
+          echo Add other actions to build,
+          echo test, and deploy your project.
+
+      - name: Run markdown lint
+        run: |
+          npm install remark-cli remark-preset-lint-consistent
+          npx remark . --use remark-preset-lint-consistent --frail


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for continuous integration (CI). The workflow is triggered on pushes and pull requests to the `main` branch, as well as via manual dispatch. It sets up a basic build job and includes a markdown linting step to enforce consistent markdown style.

CI workflow setup:

* Added `.github/workflows/ci.yml` to define a CI workflow that runs on push, pull request, and manual triggers, using an Ubuntu runner.
* Configured steps to check out the repository, run example scripts, and perform markdown linting using `remark-cli` with the `remark-preset-lint-consistent` configuration.